### PR TITLE
Altered Defend behavior

### DIFF
--- a/Assets/CardScripts/Defends/Defend.cs
+++ b/Assets/CardScripts/Defends/Defend.cs
@@ -9,7 +9,6 @@ public class Defend : AbstractDefend
 
     //When the card is played, make the small defense invisible and destroy any bullets in the collider
     public override void use(AbstractPlayer user){
-        Debug.Log(this);
         DefenseManager.Instance.makeInvisible(this.TYPE);
         DefenseManager.Instance.defend(this.TYPE, user);
     }

--- a/Assets/Managers/DefenseManager.cs
+++ b/Assets/Managers/DefenseManager.cs
@@ -42,19 +42,6 @@ public class DefenseManager : MonoBehaviour
         }
     }
 
-    //Make the defense sprite visible of the passed size
-    public void makeVisible(Type size){
-        if(size == Type.Small){
-            smallDefenseSprite.enabled = true;
-        }
-        else if(size == Type.Medium){
-            mediumDefenseSprite.enabled = true;
-        }
-        else if(size == Type.Large){
-            largeDefenseSprite.enabled = true;
-        }
-    }
-
     //Make the defense sprite invisible of the passed size
     public void makeInvisible(Type size){
         if(size == Type.Small){
@@ -111,24 +98,24 @@ public class DefenseManager : MonoBehaviour
     }
 
     void Update(){
+        //Check if time slot to see if it holds a Defend card
+        foreach(TimeSlot slot in WeaponMono.Instance.allSlots){
+            if(slot != null && slot.occupyingCard != null && slot.occupyingCard is AbstractDefend){
+                //Save the type of the occupying card
+                Type size = ((AbstractDefend)slot.occupyingCard).TYPE;
 
-        //If there is a currently selected card that is a skill
-        if(EncounterControl.Instance.hoveredCard != null && EncounterControl.Instance.hoveredCard.thisCard is AbstractDefend){
-
-            //Save the type of the selected card
-            Type size = ((AbstractDefend)EncounterControl.Instance.hoveredCard.thisCard).TYPE;
-
-            //Pass the correct defense game object depending on type of hovered card
-            if(size == Type.Small){
-                defenseFollowMouse(smallPlayerDefense);
+                //Pass the correct defense game object depending on type of hovered card
+                if(size == Type.Small){
+                    defenseFollowMouse(smallPlayerDefense);
+                }
+                else if(size == Type.Medium){
+                    defenseFollowMouse(mediumPlayerDefense);
+                }
+                else if(size == Type.Large){
+                    defenseFollowMouse(largePlayerDefense);
+                }
             }
-            else if(size == Type.Medium){
-                defenseFollowMouse(mediumPlayerDefense);
-            }
-            else if(size == Type.Large){
-                defenseFollowMouse(largePlayerDefense);
-            }
-        }
+        }     
     }
 
     //Activates the sprites and forces the passed defense Game Object to follow the mouse

--- a/Assets/Managers/EncounterControl.cs
+++ b/Assets/Managers/EncounterControl.cs
@@ -36,9 +36,6 @@ public class EncounterControl : MonoBehaviour
 
     private SpriteRenderer discardSpriteRenderer;
 
-    //Temp TimeSlot
-    TimeSlot[] timeSlots;
-
     //Holds the index of the card that is being selected
     public int position;
 

--- a/Assets/Prefabs/TimeSlot.cs
+++ b/Assets/Prefabs/TimeSlot.cs
@@ -27,10 +27,12 @@ public class TimeSlot : MonoBehaviour
         occupied = false;
     }
 
+    public AbstractCard occupyingCard;
     //Start this slot's timer based on the provided cards cost
     public IEnumerator wait(int sec, AbstractPlayer user, AbstractCard selectedCard){
         //Make the slot occupied
         occupied = true;
+        occupyingCard = selectedCard;
 
         //If its a bullet, call the node's corresponding method
         if(selectedCard is AbstractBullet){
@@ -59,11 +61,12 @@ public class TimeSlot : MonoBehaviour
 
         //Use the passed cards method
         if(selectedCard != null){
-                selectedCard.use(user);
+            selectedCard.use(user);
         }
 
         //Remove sprite and change the slot to unoccupied
         rendr.sprite = null;
+        occupyingCard = null;
         occupied = false;
     }
 


### PR DESCRIPTION
Changed defends so now the visible sprite only appears if a slot has a defend card occupying it. The card then activates when the timer runs out, like any other card